### PR TITLE
Add basic tests for training loops

### DIFF
--- a/src/splatnlp/model/cli.py
+++ b/src/splatnlp/model/cli.py
@@ -229,6 +229,10 @@ def main():
         pad_token_id=vocab[PAD],
         batch_size=args.batch_size,
         num_workers=args.num_workers,
+        pin_memory=True if args.device == "cuda" else False,
+        persistent_workers=True
+        if args.device == "cuda" and args.num_workers > 0
+        else False,
     )
 
     if args.verbose:

--- a/src/splatnlp/model/evaluation.py
+++ b/src/splatnlp/model/evaluation.py
@@ -40,11 +40,13 @@ def test_model(
             test_iter
         ):
             batch_inputs, batch_weapons, batch_targets = (
-                batch_inputs.to(device),
-                batch_weapons.to(device),
-                batch_targets.to(device),
+                batch_inputs.to(device, non_blocking=True),
+                batch_weapons.to(device, non_blocking=True),
+                batch_targets.to(device, non_blocking=True),
             )
-            key_padding_mask = (batch_inputs == vocab[pad_token]).to(device)
+            key_padding_mask = (
+                batch_inputs == vocab[pad_token]
+            ).to(device, non_blocking=True)
 
             outputs = model(
                 batch_inputs, batch_weapons, key_padding_mask=key_padding_mask

--- a/src/splatnlp/model/training_loop.py
+++ b/src/splatnlp/model/training_loop.py
@@ -181,11 +181,13 @@ def train_epoch(
         train_iter
     ):
         batch_inputs, batch_weapons, batch_targets = (
-            batch_inputs.to(device),
-            batch_weapons.to(device),
-            batch_targets.to(device),
+            batch_inputs.to(device, non_blocking=True),
+            batch_weapons.to(device, non_blocking=True),
+            batch_targets.to(device, non_blocking=True),
         )
-        key_padding_mask = (batch_inputs == vocab[pad_token]).to(device)
+        key_padding_mask = (
+            batch_inputs == vocab[pad_token]
+        ).to(device, non_blocking=True)
 
         optimizer.zero_grad()
 
@@ -270,11 +272,13 @@ def validate(
             val_iter
         ):
             batch_inputs, batch_weapons, batch_targets = (
-                batch_inputs.to(device),
-                batch_weapons.to(device),
-                batch_targets.to(device),
+                batch_inputs.to(device, non_blocking=True),
+                batch_weapons.to(device, non_blocking=True),
+                batch_targets.to(device, non_blocking=True),
             )
-            key_padding_mask = (batch_inputs == vocab[pad_token]).to(device)
+            key_padding_mask = (
+                batch_inputs == vocab[pad_token]
+            ).to(device, non_blocking=True)
 
             outputs = model(
                 batch_inputs, batch_weapons, key_padding_mask=key_padding_mask

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -1,0 +1,80 @@
+import random
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader
+
+from splatnlp.preprocessing.datasets.dataset import SetDataset, create_collate_fn
+from splatnlp.model.training_loop import train_epoch, validate
+import splatnlp.model.evaluation as evaluation
+from splatnlp.model.config import TrainingConfig
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, vocab_size: int, weapon_vocab_size: int):
+        super().__init__()
+        self.ability_embed = torch.nn.Embedding(vocab_size, 4)
+        self.weapon_embed = torch.nn.Embedding(weapon_vocab_size, 4)
+        self.fc = torch.nn.Linear(4, vocab_size)
+
+    def forward(self, abilities: torch.Tensor, weapons: torch.Tensor, key_padding_mask=None):
+        x = self.ability_embed(abilities).sum(dim=1) + self.weapon_embed(weapons).squeeze(1)
+        return self.fc(x)
+
+
+def make_dataloader(vocab_size: int = 10) -> DataLoader:
+    random.seed(0)
+    np.random.seed(0)
+    df = pd.DataFrame({"ability_tags": [[1, 2, 3], [3, 4, 5]], "weapon_id": [0, 0]})
+    dataset = SetDataset(df, vocab_size=vocab_size, num_instances_per_set=1)
+    collate = create_collate_fn(PAD_ID=0)
+    return DataLoader(dataset, batch_size=2, collate_fn=collate)
+
+
+def make_config() -> TrainingConfig:
+    return TrainingConfig(
+        num_epochs=1,
+        patience=1,
+        learning_rate=0.01,
+        weight_decay=0.0,
+        clip_grad_norm=1.0,
+        scheduler_factor=0.1,
+        scheduler_patience=1,
+        device="cpu",
+    )
+
+
+def test_train_validate_and_test_model_runs():
+    vocab = {"<PAD>": 0, "a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
+    dataloader = make_dataloader(vocab_size=len(vocab))
+    model = DummyModel(vocab_size=len(vocab), weapon_vocab_size=1)
+    config = make_config()
+
+    criterion = torch.nn.BCEWithLogitsLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    train_metrics = train_epoch(
+        model,
+        dataloader,
+        optimizer,
+        criterion,
+        config,
+        vocab,
+        verbose=False,
+    )
+    assert set(train_metrics.keys()) == {"loss", "f1", "precision", "recall", "hamming"}
+
+    val_metrics = validate(
+        model,
+        dataloader,
+        criterion,
+        config,
+        vocab,
+        verbose=False,
+    )
+    assert set(val_metrics.keys()) == {"loss", "f1", "precision", "recall", "hamming"}
+
+    test_metrics = evaluation.test_model(
+        model, dataloader, config, vocab, verbose=False
+    )
+    assert set(test_metrics.keys()) == {"loss", "f1", "precision", "recall", "hamming"}


### PR DESCRIPTION
## Summary
- add a dummy training loop test covering training, validation and testing routines
- use non-blocking device transfers in training and evaluation loops
- enable pinned memory and persistent dataloader workers on CUDA in CLI

## Testing
- `poetry run pytest -q`