### PR TITLE
Add CLI docstrings

### DIFF
--- a/src/splatnlp/embeddings/cli.py
+++ b/src/splatnlp/embeddings/cli.py
@@ -52,6 +52,14 @@ def load_data(data_path, table_name=None):
 
 
 def main():
+    """CLI entry point for Doc2Vec embedding utilities.
+
+    The script supports training, inference, dimensionality reduction and
+    clustering modes. It expects tokenized data and vocabulary JSON files.
+    Depending on ``--mode``, it saves a Doc2Vec model or derived vectors and
+    clustering results under ``--output_dir``.
+    """
+
     parser = argparse.ArgumentParser(
         description="Train and use Doc2Vec embeddings for SplatNLP"
     )

--- a/src/splatnlp/model/cli.py
+++ b/src/splatnlp/model/cli.py
@@ -62,6 +62,14 @@ def load_data(data_path, table_name=None):
 
 
 def main():
+    """Train a SetCompletionModel via command line.
+
+    Required arguments specify the tokenized dataset and vocabulary JSON files.
+    Additional options configure model hyperparameters and training behavior.
+    The trained model (``model.pth``), metrics history and parameter summary are
+    saved in ``--output_dir``.
+    """
+
     parser = argparse.ArgumentParser(description="Train a SetCompletionModel")
     parser.add_argument(
         "--data_path",

--- a/src/splatnlp/monosemantic_sae/cli.py
+++ b/src/splatnlp/monosemantic_sae/cli.py
@@ -63,6 +63,14 @@ def load_data(data_path, table_name=None):
 
 
 def main():
+    """Train a SetCompletionModel or its autoencoder variant via CLI.
+
+    Input paths for tokenized data and vocabularies are required. When
+    ``--pretrained_model_path`` is provided, an autoencoder is trained on the
+    pretrained model's activations. The resulting weights, metrics history and
+    model parameters are written to ``--output_dir``.
+    """
+
     parser = argparse.ArgumentParser(
         description="Train an Autoencoder for SetCompletionModel or a standard SetCompletionModel"
     )


### PR DESCRIPTION
## Summary
- add main() docstrings for command line scripts

## Testing
- `poetry run pytest -q`