### PR TITLE
Improve server docs

### DIFF
--- a/src/splatnlp/serve/inference.py
+++ b/src/splatnlp/serve/inference.py
@@ -1,3 +1,5 @@
+"""Utility functions for running inference with ``SetCompletionModel``."""
+
 import logging
 import time
 
@@ -17,6 +19,8 @@ def inference(
     weapon_vocab: dict[str, int],
     pad_token_id: int,
 ) -> tuple[list[tuple[str, float]], float]:
+    """Generate predictions for a tokenized build."""
+
     start_time = time.time()
     logging.info("Starting inference")
     logging.info(f"Target: {target}")
@@ -46,6 +50,8 @@ def inference(
 
 
 def normalized_entropy(preds: np.ndarray) -> float:
+    """Return the entropy normalized to ``[0, 1]`` for a distribution."""
+
     probs = preds / np.sum(preds)
     entropy = -np.sum(probs * np.log2(probs + 1e-10))
     max_entropy = np.log2(len(preds))

--- a/src/splatnlp/serve/load_model.py
+++ b/src/splatnlp/serve/load_model.py
@@ -1,3 +1,11 @@
+"""Utility functions for loading model artifacts used by the API server.
+
+The helpers in this module download vocabularies, model parameters and the
+pre-trained ``SetCompletionModel`` from URLs.  ``load_from_env`` derives those
+URLs from a set of environment variables and provides a single entry point used
+by ``splatnlp.serve.app`` during application startup.
+"""
+
 import io
 import logging
 import os
@@ -13,12 +21,16 @@ logger = logging.getLogger(__name__)
 
 
 def load_vocabulary(vocab_url: str) -> dict[str, int]:
+    """Download and deserialize a vocabulary JSON file."""
+
     logger.info(f"Loading vocabulary from {vocab_url}")
     response = requests.get(vocab_url)
     return orjson.loads(response.content)
 
 
 def load_model(model_url: str, model_params: dict) -> SetCompletionModel:
+    """Instantiate and load a ``SetCompletionModel`` from a URL."""
+
     logger.info(f"Loading model from {model_url}")
     response = requests.get(model_url)
     response_data = io.BytesIO(response.content)
@@ -34,6 +46,8 @@ def load_model(model_url: str, model_params: dict) -> SetCompletionModel:
 
 
 def load_model_params(params_url: str) -> dict:
+    """Load the model parameter dictionary from ``params_url``."""
+
     logger.info(f"Loading model parameters from {params_url}")
     response = requests.get(params_url)
     return orjson.loads(response.content)
@@ -46,6 +60,8 @@ def load(
     params_url: str,
     info_url: str,
 ) -> tuple[dict, dict, int, dict, SetCompletionModel]:
+    """Load the model, vocabularies and metadata from the provided URLs."""
+
     vocab = load_vocabulary(vocab_url)
     weapon_vocab = load_vocabulary(weapon_vocab_url)
     model_params = load_model_params(params_url)
@@ -56,6 +72,20 @@ def load(
 
 
 def load_from_env() -> tuple[dict, dict, int, dict, SetCompletionModel]:
+    """Load all required artifacts using environment variables.
+
+    The function expects either individual URLs or a base DigitalOcean
+    Spaces configuration:
+
+    ``VOCAB_URL`` / ``WEAPON_VOCAB_URL`` / ``MODEL_URL`` / ``PARAMS_URL`` /
+    ``INFO_URL``
+        Direct links to the respective JSON or model files.
+    ``DO_SPACES_ML_ENDPOINT`` and ``DO_SPACES_ML_DIR``
+        If any of the above URLs are missing, these variables are combined to
+        build a base path ``{ENDPOINT}/{DIR}`` from which default file names are
+        inferred.
+    """
+
     vocab_url = os.getenv("VOCAB_URL")
     weapon_vocab_url = os.getenv("WEAPON_VOCAB_URL")
     model_url = os.getenv("MODEL_URL")


### PR DESCRIPTION
## Summary
- document FastAPI app and API response
- add explanations of environment variables for model loading
- document inference helper functions

## Testing
- `poetry run isort src/splatnlp/serve/app.py src/splatnlp/serve/load_model.py src/splatnlp/serve/inference.py`
- `poetry run black src/splatnlp/serve/app.py src/splatnlp/serve/load_model.py src/splatnlp/serve/inference.py`
- `poetry run pytest -q`