### PR TITLE
Add docstrings for reconstruction modules

### DIFF
--- a/src/splatnlp/utils/reconstruct/allocator.py
+++ b/src/splatnlp/utils/reconstruct/allocator.py
@@ -1,3 +1,14 @@
+"""Allocate predicted abilities to a legal Splatoon gear build.
+
+This module defines :class:`Allocator` for the reconstruction pipeline. It
+searches possible assignments of capstone abilities to gear slots, choosing
+between main and sub slots while respecting game rules. The allocator
+minimises total Ability Points (AP) while meeting each requested ability's
+minimum requirement.
+
+See ``README.md`` in this directory for a full description of the strategy.
+"""
+
 import logging
 import math
 from itertools import combinations

--- a/src/splatnlp/utils/reconstruct/beam_search.py
+++ b/src/splatnlp/utils/reconstruct/beam_search.py
@@ -1,3 +1,12 @@
+"""Beam search utilities for gear build reconstruction.
+
+This module exposes :func:`reconstruct_build`, which incrementally assembles
+"capstone" abilities predicted by a model.  At each step it evaluates
+candidate sets with :class:`Allocator` and keeps the highest scoring legal
+build.  The procedure is described in detail in ``README.md`` in this
+directory.
+"""
+
 import math
 from dataclasses import dataclass
 from typing import Optional


### PR DESCRIPTION
## Summary
- document the beam search and allocation utilities
- mention that the full procedure is described in the module README

## Testing
- `poetry run pytest -q`