### PR TITLE
Improve dataset and dataloader documentation

### DIFF
--- a/src/splatnlp/preprocessing/datasets/dataset.py
+++ b/src/splatnlp/preprocessing/datasets/dataset.py
@@ -15,16 +15,37 @@ class SetDataset(Dataset):
         skew_factor: float = 1.2,
         null_token: int | None = None,
     ):
-        """
-        Args:
-            df: DataFrame with 'ability_tags' and 'weapon_id' columns.
-            vocab_size: Total number of tokens in your vocabulary.
-            num_instances_per_set: Number of instances to generate per set.
-            skew_factor: Adjust this value to control the skew of the
-                removal distribution. Higher values increase the probability of
-                generating more removals.
-            null_token: The token to use for generating from an empty set. If
-                None, will not generate empty sets. Defaults to None.
+        """Dataset that samples subsets of ability tag lists.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            DataFrame with two required columns:
+            ``ability_tags`` (``list[int]``) containing tokenised ability
+            tag IDs and ``weapon_id`` (``int``) indicating the
+            corresponding weapon.
+        vocab_size : int
+            Size of the vocabulary including special tokens.
+        num_instances_per_set : int, default ``5``
+            Number of random subsets generated for each original set. If
+            ``null_token`` is provided an additional instance containing only
+            that token is produced.
+        skew_factor : float, default ``1.2``
+            Controls the distribution of how many tokens are removed. Higher
+            values bias the sampling towards removing more tokens.
+        null_token : int | None, default ``None``
+            Optional token used to generate an empty input sequence. When set,
+            one extra instance per set is yielded consisting solely of this
+            token.
+
+        Sampling logic
+        ---------------
+        For every ability tag list ``S`` and each generated instance,
+        ``k`` indices are randomly removed from ``S`` where ``k`` is drawn
+        from :meth:`weighted_random_removals`. This method uses a triangular
+        distribution shaped by ``skew_factor`` so that larger ``k`` values are
+        slightly more likely. The remaining tokens form the input while ``S``
+        itself is returned as the target along with ``weapon_id``.
         """
         self.ability_tags = df["ability_tags"].tolist()
         self.weapon_ids = df["weapon_id"].tolist()

--- a/src/splatnlp/preprocessing/datasets/generate_datasets.py
+++ b/src/splatnlp/preprocessing/datasets/generate_datasets.py
@@ -70,27 +70,36 @@ def generate_dataloaders(
     null_token_id: int | None = None,
     **kwargs,
 ) -> tuple[DataLoader, DataLoader, DataLoader]:
-    """Generate DataLoaders for train, validation, and test sets.
+    """Create loaders for the provided train, validation and test sets.
 
-    Args:
-        train_set (pd.DataFrame): The training dataset.
-        validation_set (pd.DataFrame): The validation dataset.
-        test_set (pd.DataFrame): The test dataset.
-        vocab_size (int): The size of the vocabulary.
-        pad_token_id (int): The ID of the padding token.
-        num_instances_per_set (int, optional): Number of instances to
-            generate per set. Defaults to 5.
-        skew_factor (float, optional): Factor to control the skew of the
-            removal distribution. Defaults to 1.2.
-        null_token_id (int | None, optional): The ID of the null token. If
-            None, empty sets are not generated. Defaults to None.
-        **kwargs: Additional keyword arguments for DataLoader.
+    Parameters
+    ----------
+    train_set, validation_set, test_set : pd.DataFrame
+        DataFrames containing ``ability_tags`` (``list[int]``) and
+        ``weapon_id`` (``int``) columns.
+    vocab_size : int
+        Size of the vocabulary.
+    pad_token_id : int
+        Token ID used for padding in the collate function.
+    num_instances_per_set : int, default ``5``
+        Passed to :class:`SetDataset`.
+    skew_factor : float, default ``1.2``
+        Passed to :class:`SetDataset`.
+    null_token_id : int | None, default ``None``
+        Passed to :class:`SetDataset`.
+    **kwargs : Any
+        Additional keyword arguments forwarded to :class:`DataLoader`.
 
-    Returns:
-        tuple[DataLoader, DataLoader, DataLoader]:
-            - DataLoader: The DataLoader for the training set.
-            - DataLoader: The DataLoader for the validation set.
-            - DataLoader: The DataLoader for the test set.
+    Returns
+    -------
+    tuple[DataLoader, DataLoader, DataLoader]
+        ``(train_loader, validation_loader, test_loader)``.
+
+    Notes
+    -----
+    The default DataLoader settings are ``batch_size=32``, ``shuffle=True``,
+    ``num_workers=0`` and ``drop_last=True``. Any values provided via
+    ``kwargs`` override these defaults.
     """
     DEFAULT_BATCH_SIZE = 32
     DEFAULT_SHUFFLE = True


### PR DESCRIPTION
## Summary
- document SetDataset requirements and sampling logic
- clarify defaults and return order in `generate_dataloaders`

## Testing
- `poetry run pytest -q`