### PR TITLE
Improve beam search tracing

### DIFF
--- a/tests/test_greedy_closure.py
+++ b/tests/test_greedy_closure.py
@@ -1,0 +1,29 @@
+import pytest
+
+from splatnlp.utils.constants import NULL
+from splatnlp.utils.reconstruct.beam_search import greedy_closure
+
+
+def simple_predict(tokens, weapon_id):
+    key = tuple(tok for tok in tokens if tok != NULL)
+    if not key:
+        return {"ink_saver_main_3": 0.6}
+    if key == ("ink_saver_main_3",):
+        return {"run_speed_up_6": 0.7}
+    return {}
+
+
+def test_greedy_closure_tracing_steps():
+    caps, step, traces = greedy_closure(
+        simple_predict, "w", {}, record_traces=True, start_step=0
+    )
+    assert set(caps.keys()) == {"ink_saver_main_3", "run_speed_up_6"}
+    assert step == 2
+    assert [t.step for t in traces] == [0, 1, 2]
+    assert list(traces[0].partial_caps.keys()) == []
+    assert set(traces[1].partial_caps.keys()) == {"ink_saver_main_3"}
+    assert set(traces[2].partial_caps.keys()) == {
+        "ink_saver_main_3",
+        "run_speed_up_6",
+    }
+

--- a/tests/test_reconstruct_tracing.py
+++ b/tests/test_reconstruct_tracing.py
@@ -1,0 +1,36 @@
+from splatnlp.utils.constants import NULL
+from splatnlp.utils.reconstruct.allocator import Allocator
+from splatnlp.utils.reconstruct.beam_search import reconstruct_build
+
+
+def predict(tokens, weapon_id):
+    key = tuple(tok for tok in tokens if tok != NULL)
+    if not key:
+        return {"ink_saver_main_3": 0.6}
+    if key == ("ink_saver_main_3",):
+        return {"run_speed_up_6": 0.7}
+    return {}
+
+
+def test_reconstruct_build_returns_traces():
+    allocator = Allocator()
+    result_builds, traces = reconstruct_build(
+        predict,
+        "w",
+        [],
+        allocator,
+        beam_size=1,
+        max_steps=1,
+        record_traces=True,
+    )
+    assert result_builds is not None
+    assert traces is not None
+    assert len(result_builds) == 1
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace[-1].step == 3
+    assert set(trace[-1].partial_caps.keys()) == {
+        "ink_saver_main_3",
+        "run_speed_up_6",
+    }
+


### PR DESCRIPTION
## Summary
- improve trace handling for greedy closure and beam search
- add per-beam trace storage
- fix step counter and add regression tests
- document global step counter

## Testing
- `poetry run isort .`
- `poetry run black .`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'dash_ag_grid')*
- `poetry run pytest tests/test_greedy_closure.py tests/test_reconstruct_tracing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6132244083308cc5fed7fb926635