### PR TITLE
Feature/beam search improvements

### DIFF
--- a/tests/test_greedy_closure.py
+++ b/tests/test_greedy_closure.py
@@ -1,0 +1,29 @@
+import pytest
+
+from splatnlp.utils.constants import NULL
+from splatnlp.utils.reconstruct.beam_search import greedy_closure
+
+
+def simple_predict(tokens, weapon_id):
+    key = tuple(tok for tok in tokens if tok != NULL)
+    if not key:
+        return {"ink_saver_main_3": 0.6}
+    if key == ("ink_saver_main_3",):
+        return {"run_speed_up_6": 0.7}
+    return {}
+
+
+def test_greedy_closure_tracing_steps():
+    caps, step, traces = greedy_closure(
+        simple_predict, "w", {}, record_traces=True, start_step=0
+    )
+    assert set(caps.keys()) == {"ink_saver_main_3", "run_speed_up_6"}
+    assert step == 2
+    assert [t.step for t in traces] == [0, 1, 2]
+    assert list(traces[0].partial_caps.keys()) == []
+    assert set(traces[1].partial_caps.keys()) == {"ink_saver_main_3"}
+    assert set(traces[2].partial_caps.keys()) == {
+        "ink_saver_main_3",
+        "run_speed_up_6",
+    }
+

--- a/tests/test_reconstruct_tracing.py
+++ b/tests/test_reconstruct_tracing.py
@@ -1,0 +1,36 @@
+from splatnlp.utils.constants import NULL
+from splatnlp.utils.reconstruct.allocator import Allocator
+from splatnlp.utils.reconstruct.beam_search import reconstruct_build
+
+
+def predict(tokens, weapon_id):
+    key = tuple(tok for tok in tokens if tok != NULL)
+    if not key:
+        return {"ink_saver_main_3": 0.6}
+    if key == ("ink_saver_main_3",):
+        return {"run_speed_up_6": 0.7}
+    return {}
+
+
+def test_reconstruct_build_returns_traces():
+    allocator = Allocator()
+    result_builds, traces = reconstruct_build(
+        predict,
+        "w",
+        [],
+        allocator,
+        beam_size=1,
+        max_steps=1,
+        record_traces=True,
+    )
+    assert result_builds is not None
+    assert traces is not None
+    assert len(result_builds) == 1
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace[-1].step == 3
+    assert set(trace[-1].partial_caps.keys()) == {
+        "ink_saver_main_3",
+        "run_speed_up_6",
+    }
+


### PR DESCRIPTION
This pull request introduces a tracing mechanism for the `greedy_closure` and `reconstruct_build` functions in the `beam_search` module, allowing detailed tracking of intermediate steps during execution. It also updates the data structures and return types to support this feature and adds corresponding unit tests to ensure correctness.

### Enhancements to Tracing and Data Structures:
* Added a `trace` attribute to the `BeamState` class to store a list of `TraceFrame` objects, which record intermediate states during beam search. (`src/splatnlp/utils/reconstruct/beam_search.py`, [src/splatnlp/utils/reconstruct/beam_search.pyR23](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cR23))
* Updated `greedy_closure` to support tracing with the `record_traces` flag, returning `step` and `traces` alongside `capstones` when tracing is enabled. (`src/splatnlp/utils/reconstruct/beam_search.py`, [[1]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cL54-R76) [[2]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cR115-R126) [[3]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cR145-R147)
* Modified `reconstruct_build` to handle per-build traces, returning a list of traces for each build when tracing is enabled. (`src/splatnlp/utils/reconstruct/beam_search.py`, [[1]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cL156-R177) [[2]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cL172-R193) [[3]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cR227-R240) [[4]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cL221-R283)

### Beam Search Logic Updates:
* Enhanced beam search to propagate traces through candidate states and record final frames for each beam state at the end of each step. (`src/splatnlp/utils/reconstruct/beam_search.py`, [[1]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cR295-R296) [[2]](diffhunk://#diff-2fd9561ca56a809e06859be91c2e1e58f6a274ae1ebfadcccdf2e8d4503c9f3cL306-R437)

### Unit Tests:
* Added `test_greedy_closure_tracing_steps` to validate tracing in `greedy_closure`, ensuring correct step counts and intermediate states. (`tests/test_greedy_closure.py`, [tests/test_greedy_closure.pyR1-R29](diffhunk://#diff-c26b24b9a333c91113efd824988e3183fa7db3258edd7d235acc4e14d098878bR1-R29))
* Added `test_reconstruct_build_returns_traces` to verify that `reconstruct_build` correctly returns traces for each build and records the final step accurately. (`tests/test_reconstruct_tracing.py`, [tests/test_reconstruct_tracing.pyR1-R36](diffhunk://#diff-60a6819066ceab19d442b06c999a14c17fe3d5bedd94d12b17bd0f22612a0b38R1-R36))